### PR TITLE
Added --use-fake-ui-for-media-stream flag

### DIFF
--- a/lib/selenium_connect/runners/chrome.rb
+++ b/lib/selenium_connect/runners/chrome.rb
@@ -28,6 +28,10 @@ class SeleniumConnect
           log_path = File.join(Dir.getwd, config.log, 'chrome')
           caps['chrome.switches'] = ["--user-data-dir=#{log_path}", '--enable-logging', '--v=1', "--log-net-log=#{log_path}/net_log.log", '--net-log-level=0']
         end
+
+        # Add the flag to bypass the media stream infobar by selecting the default device for media streams 
+        caps['chromeOptions'] = {"args" => [ "--use-fake-ui-for-media-stream" ]}
+
         caps
       end
 


### PR DESCRIPTION
- Added as part of ChromeDriver’s startup capabilities
